### PR TITLE
Adds cache busting by appending a build timestamp to all known asset links

### DIFF
--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -123,11 +123,11 @@ function setColor() {
     var color = localStorage.getItem('doctave-color')
 
     if (color === 'dark') {
-        document.querySelector("link[rel='stylesheet'][href*='prism-']").href = "/assets/prism-atom-dark.css";
+        document.querySelector("link[rel='stylesheet'][href*='prism-']").href = "/assets/prism-atom-dark.css?v=" + DOCTAVE_TIMESTAMP;
         document.getElementsByTagName('html')[0].classList.remove('light');
         document.getElementsByTagName('html')[0].classList.add('dark');
     } else {
-        document.querySelector("link[rel='stylesheet'][href*='prism-']").href = "/assets/prism-ghcolors.css";
+        document.querySelector("link[rel='stylesheet'][href*='prism-']").href = "/assets/prism-ghcolors.css?" + DOCTAVE_TIMESTAMP;
         document.getElementsByTagName('html')[0].classList.remove('dark');
         document.getElementsByTagName('html')[0].classList.add('light');
     }

--- a/templates/page.html
+++ b/templates/page.html
@@ -11,10 +11,10 @@
 
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Source+Sans+Pro:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" type="text/css" href="/assets/normalize.css" media="screen" />
-    <link rel="stylesheet" type="text/css" href="/assets/doctave-style.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="/assets/normalize.css?v={{ timestamp }}" media="screen" />
+    <link rel="stylesheet" type="text/css" href="/assets/doctave-style.css?v={{ timestamp }}" media="screen" />
 
-    <link rel="stylesheet" type="text/css" href="/assets/prism-ghcolors.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="/assets/prism-ghcolors.css?v={{ timestamp }}" media="screen" />
 
     {{#if (eq build_mode "dev") }}
     <script type='text/javascript' src="/assets/livereload.js?port=35729" async="" defer=""></script>
@@ -39,6 +39,7 @@
     {{/if}}
 
     <script>
+    var DOCTAVE_TIMESTAMP = "{{ timestamp }}";
     var color = localStorage.getItem('doctave-color')
 
     if (color === 'dark') {
@@ -110,10 +111,10 @@
             </div>
         </div>
     </div>
-    <script type="text/javascript" src="/assets/mermaid.js"></script>
-    <script type="text/javascript" src="/assets/elasticlunr.js"></script>
-    <script type="text/javascript" src="/assets/doctave-app.js"></script>
-    <script type="text/javascript" src="/assets/prism.js"></script>
+    <script type="text/javascript" src="/assets/mermaid.js?v={{ timestamp }}"></script>
+    <script type="text/javascript" src="/assets/elasticlunr.js?v={{ timestamp }}"></script>
+    <script type="text/javascript" src="/assets/doctave-app.js?v={{ timestamp }}"></script>
+    <script type="text/javascript" src="/assets/prism.js?v={{ timestamp }}"></script>
 </body>
 
 </html>

--- a/tests/build_cmd.rs
+++ b/tests/build_cmd.rs
@@ -441,3 +441,20 @@ integration_test!(include_header, |area| {
     let head = Path::new("site").join("_head.html");
     area.refute_exists(&head);
 });
+
+integration_test!(cache_buster, |area| {
+    area.create_config();
+    area.mkdir("docs");
+    area.write_file(Path::new("docs").join("README.md"), b"# Hi");
+
+    let result = area.cmd(&["build"]);
+    assert_success(&result);
+
+    let index = Path::new("site").join("index.html");
+
+    // No access to the actual timestamp, but we should be fine until unix timestamps
+    // roll over to start with the number 2.
+    //
+    // Famous last words ofc...
+    area.assert_contains(&index, "doctave-style.css?v=1");
+});


### PR DESCRIPTION
May have to improve on this in the future, but seems like browsers respect query parameters these days:

https://css-tricks.com/strategies-for-cache-busting-css/

User defined assets are not managed at the moment.